### PR TITLE
fix: constSysfsExpr no longer working because of stupid babel import & fix plugins not working on non steam pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 		"rollup-plugin-polyfill-node": "^0.13.0",
 		"rollup-plugin-scss": "^4.0.1",
 		"sass": "^1.89.1",
+		"terser": "^5.43.1",
 		"tslib": "^2.8.1"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       sass:
         specifier: ^1.89.1
         version: 1.89.1
+      terser:
+        specifier: ^5.43.1
+        version: 5.43.1
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -1380,8 +1383,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  terser@5.41.0:
-    resolution: {integrity: sha512-H406eLPXpZbAX14+B8psIuvIr8+3c+2hkuYzpMkoE0ij+NdsVATbA78vb8neA/eqrj7rywa2pIkdmWRsXW6wmw==}
+  terser@5.43.1:
+    resolution: {integrity: sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -2302,7 +2305,7 @@ snapshots:
     dependencies:
       serialize-javascript: 6.0.2
       smob: 1.5.0
-      terser: 5.41.0
+      terser: 5.43.1
     optionalDependencies:
       rollup: 4.42.0
 
@@ -2796,7 +2799,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  terser@5.41.0:
+  terser@5.43.1:
     dependencies:
       '@jridgewell/source-map': 0.3.6
       acorn: 8.14.1

--- a/src/plugin-api.ts
+++ b/src/plugin-api.ts
@@ -189,7 +189,11 @@ function InitializePlugins() {
 	}
 
 	function WebkitInitializeIPC() {
-		SteamClient?.BrowserView?.RegisterForMessageFromParent((messageId: string, data: string) => {
+		if (typeof SteamClient === 'undefined') {
+			return;
+		}
+
+		SteamClient.BrowserView?.RegisterForMessageFromParent((messageId: string, data: string) => {
 			if (messageId !== IPCMessageId) {
 				return;
 			}
@@ -271,3 +275,4 @@ function InitializePlugins() {
 }
 
 export { ExecutePluginModule, InitializePlugins };
+

--- a/src/static-embed.ts
+++ b/src/static-embed.ts
@@ -1,12 +1,15 @@
-import { Plugin, SourceDescription, TransformPluginContext } from 'rollup';
-import fs from 'fs';
-import path from 'path';
-import { createFilter } from '@rollup/pluginutils';
-import MagicString from 'magic-string';
 import * as parser from '@babel/parser';
-import traverse from '@babel/traverse';
-import * as glob from 'glob';
+import { createFilter } from '@rollup/pluginutils';
 import chalk from 'chalk';
+import fs from 'fs';
+import * as glob from 'glob';
+import MagicString from 'magic-string';
+import path from 'path';
+import { Plugin, SourceDescription, TransformPluginContext } from 'rollup';
+
+// Stupid fix because @babel/traverse exports a CommonJS module
+import _traverse from '@babel/traverse';
+const traverse = (_traverse as any).default as typeof _traverse;
 
 interface EmbedPluginOptions {
 	include?: string | RegExp | (string | RegExp)[];

--- a/src/transpiler.ts
+++ b/src/transpiler.ts
@@ -1,23 +1,24 @@
-import { OutputOptions, RollupOptions, rollup } from 'rollup';
-import json from '@rollup/plugin-json';
-import commonjs from '@rollup/plugin-commonjs';
-import replace from '@rollup/plugin-replace';
-import typescript from '@rollup/plugin-typescript';
-import resolve, { nodeResolve } from '@rollup/plugin-node-resolve';
-import terser from '@rollup/plugin-terser';
 import babel from '@rollup/plugin-babel';
-import nodePolyfills from 'rollup-plugin-polyfill-node';
+import commonjs from '@rollup/plugin-commonjs';
+import json from '@rollup/plugin-json';
+import resolve, { nodeResolve } from '@rollup/plugin-node-resolve';
+import replace from '@rollup/plugin-replace';
+import terser from '@rollup/plugin-terser';
+import typescript from '@rollup/plugin-typescript';
 import url from '@rollup/plugin-url';
+import { InputPluginOption, OutputBundle, OutputOptions, RollupOptions, rollup } from 'rollup';
+import nodePolyfills from 'rollup-plugin-polyfill-node';
+import { minify_sync } from 'terser';
 
 import scss from 'rollup-plugin-scss';
 import * as sass from 'sass';
 
 import chalk from 'chalk';
-import { Logger } from './logger';
 import fs from 'fs';
+import { Logger } from './logger';
 
-import injectProcessEnv from 'rollup-plugin-inject-process-env';
 import dotenv from 'dotenv';
+import injectProcessEnv from 'rollup-plugin-inject-process-env';
 import { ExecutePluginModule, InitializePlugins } from './plugin-api';
 import constSysfsExpr from './static-embed';
 
@@ -54,7 +55,7 @@ export interface TranspilerProps {
 const WrappedCallServerMethod = 'const __call_server_method__ = (methodName, kwargs) => Millennium.callServerMethod(pluginName, methodName, kwargs)';
 const WrappedCallable = 'const __wrapped_callable__ = (route) => MILLENNIUM_API.callable(__call_server_method__, route)';
 
-const ConstructFunctions = (parts: any) => {
+const ConstructFunctions = (parts: string[]): string => {
 	return parts.join('\n');
 };
 
@@ -63,8 +64,8 @@ function generate(code: string) {
 	return `let PluginEntryPointMain = function() { ${code} return millennium_main; };`;
 }
 
-function InsertMillennium(type: ComponentType, props: TranspilerProps) {
-	const generateBundle = (_: unknown, bundle: any) => {
+function InsertMillennium(type: ComponentType, props: TranspilerProps): InputPluginOption {
+	const generateBundle = (_: unknown, bundle: OutputBundle) => {
 		for (const fileName in bundle) {
 			if (bundle[fileName].type != 'chunk') {
 				continue;
@@ -72,7 +73,7 @@ function InsertMillennium(type: ComponentType, props: TranspilerProps) {
 
 			Logger.Info('millenniumAPI', 'Bundling into ' + ComponentType[type] + ' module... ' + chalk.green.bold('okay'));
 
-			bundle[fileName].code = ConstructFunctions([
+			let code = ConstructFunctions([
 				`const MILLENNIUM_IS_CLIENT_MODULE = ${type === ComponentType.Plugin ? 'true' : 'false'};`,
 				`const pluginName = "${props.strPluginInternalName}";`,
 				InitializePlugins.toString(),
@@ -83,6 +84,12 @@ function InsertMillennium(type: ComponentType, props: TranspilerProps) {
 				ExecutePluginModule.toString(),
 				ExecutePluginModule.name + '()',
 			]);
+
+			if (props.bTersePlugin) {
+				code = minify_sync(code).code ?? code;
+			}
+
+			bundle[fileName].code = code;
 		}
 	};
 
@@ -112,7 +119,7 @@ async function MergePluginList(plugins: any[]) {
 	return [...plugins, ...filteredCustomPlugins];
 }
 
-async function GetPluginComponents(props: TranspilerProps) {
+async function GetPluginComponents(props: TranspilerProps): Promise<InputPluginOption[]> {
 	let tsConfigPath = '';
 	const frontendDir = GetFrontEndDirectory();
 

--- a/src/transpiler.ts
+++ b/src/transpiler.ts
@@ -161,7 +161,6 @@ async function GetPluginComponents(props: TranspilerProps): Promise<InputPluginO
 		resolve(),
 		json(),
 		constSysfsExpr(),
-		injectProcessEnv(envVars),
 		replace({
 			delimiters: ['', ''],
 			preventAssignment: true,
@@ -174,9 +173,14 @@ async function GetPluginComponents(props: TranspilerProps): Promise<InputPluginO
 		}),
 	];
 
+	if (envVars.length > 0) {
+		pluginList.push(injectProcessEnv(envVars));
+	}
+
 	if (props.bTersePlugin) {
 		pluginList.push(terser());
 	}
+
 	return pluginList;
 }
 
@@ -196,7 +200,6 @@ async function GetWebkitPluginComponents(props: TranspilerProps) {
 		commonjs(),
 		json(),
 		constSysfsExpr(),
-		injectProcessEnv(envVars),
 		replace({
 			delimiters: ['', ''],
 			preventAssignment: true,
@@ -209,6 +212,10 @@ async function GetWebkitPluginComponents(props: TranspilerProps) {
 			babelHelpers: 'bundled',
 		}),
 	];
+
+	if (envVars.length > 0) {
+		pluginList.push(injectProcessEnv(envVars));
+	}
 
 	pluginList = await MergePluginList(pluginList);
 


### PR DESCRIPTION
constSysfsExpr got broken in 2.6.3 because all packages got put into rollups external and for some reason you need to call an extra .default on @babel/traverse.
Also fixed plugins still not working on non steam pages because js just returns an error even though we are calling it with questionmarks or if you just do `if (!SteamClient)`.

Also tried speeding up the build times (as my plugin Extendium is taking 10 seconds to build each time) by trying to use `rollup-plugin-esbuild` but that came with a bunch of build bugs but might be worth looking into.